### PR TITLE
Remove "list key steps" LO

### DIFF
--- a/episodes/1-intro-reproducible-examples.Rmd
+++ b/episodes/1-intro-reproducible-examples.Rmd
@@ -28,7 +28,6 @@ In this first episode we will introduce the concept of a *minimal reproducible e
 ::: objectives
 -   Describe a minimal reproducible example and its requirements.
 -   Recognize how creating a minimal reproducible example can help you solve problems in your code.
--   List the key steps to creating a minimal reproducible example.
 -   Explain the benefits of creating a minimal reproducible example both for you and for others.
 -   Load in the rodent survey data and briefly explain its contents.
 :::


### PR DESCRIPTION
Removed the Ep 1 LO that asked them to list the key steps. Demo participants reported that they didn't feel that they were well enough acquainted with the road map in this episode to fully list the key steps, especially since Ep 1 doesn't really focus on this beyond briefly introducing it. I went ahead and removed this LO.

A different approach might be to spend more time introducing the steps in this episode. But I think it's fine to have them accomplish this LO in later episodes.

Fixes #189 
